### PR TITLE
Remove Meetup list from past events page

### DIFF
--- a/past.html
+++ b/past.html
@@ -7,8 +7,6 @@ permalink: /past
   <h1 class="center">Past Events</h1>
 </article>
 
-{% include body-pastevents.html %}
-
 {% include body-videos.html %}
 
 <article id="schedule">


### PR DESCRIPTION
The meat of the Past Events page was getting pushed below the fold. This PR removes the Meetup event list from the Past Events page.

As an alternative, we could include the Meetup link in the markdown section below. Or not at all.

<img width="1539" alt="Screen Shot 2019-03-10 at 2 52 07 PM" src="https://user-images.githubusercontent.com/15916062/54089895-57b7a100-4344-11e9-909a-9cea6430bab9.png">
