### PR TITLE
Create a page per event for linking

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,3 +10,8 @@ github_username:  transittechies
 # Build settings
 markdown: kramdown
 highlighter: rouge
+permalink: /:categories/:year/:month/:day/:title
+collections:
+  events:
+    output: true
+    permalink: /:collection/:title

--- a/_drafts/draftevent.md
+++ b/_drafts/draftevent.md
@@ -1,0 +1,25 @@
+---
+layout: event
+title: "Transit Techies NYC X: Y"
+eventdate: "<DATE AND TIME IN YYYY-MM-DDThh:mm-tz format>"
+location: "<NAME OF VENUE>"
+address: "<ADDRESS OF VENUE>"
+---
+
+## Meetup information
+
+- RSVP: [Click to go to meetup.com to RSVP](#)
+- Date: {% if page.eventdate %}{{ page.eventdate | date: "%A, %B %-d, %Y" }}{% endif %}
+- Time: 6:30 PM to 8:30 PM
+- Where: {% if page.location %}{{ page.location }}{% endif %}, {% if page.address %}{{ page.address }}{% endif %}
+
+<SPEAKERS>
+
+
+## Written recap
+
+TBD
+
+## Speakers and links
+
+TBD

--- a/_events/transit-techies-nyc-1.md
+++ b/_events/transit-techies-nyc-1.md
@@ -1,0 +1,38 @@
+---
+layout: event
+title: "Transit Techies NYC 1: Christening the Code Train"
+date: "2018-05-23T19:00-04:00"
+location: "Intersection"
+address: "10 Hudson Yards, New York, NY 10001"
+---
+
+## Meetup information
+
+- RSVP: [Click to go to meetup.com to RSVP](https://www.meetup.com/Transit-Techies-NYC/events/249952831/)
+- Date: {% if page.date %}{{ page.date | date: "%A, %B %-d, %Y" }}{% endif %}
+- Time: 7:00 PM to 9:00 PM
+- Where: {% if page.location %}{{ page.location }}{% endif %}, {% if page.address %}{{ page.address }}{% endif %}
+
+Will Geary will show how to use Processing & P5.js to build transit visualizations, specifically for TransitFlow.
+
+Kathryn Killebrew will walk us through lessons from working on trip routing for GoPhillyGo (https://gophillygo.org), a trip planning tool for biking, walking, and transit.
+
+Jiaxu Zhou will explore analytical methods for mapping potential Citibike usage in the outer boroughs.
+
+Dan Vanderkam will discuss NYC Transit Explorer, a tool built by Sidewalk Labs which shows how long it would take to get anywhere in the city via transit, including scenario analysis.
+
+## Written recap
+
+Recap by Pranav Badami on [Medium](https://medium.com/@pranavbadami/transittechiesnyc-a-quick-recap-of-the-inaugural-meetup-b7c3a81428f2).
+
+## Speakers and links
+
+- Will Geary [@wgeary](https://twitter.com/wgeary)
+  - How to use Processing & P5.js to build transit visualizations, specifically for [TransitFlow](https://github.com/transitland/transitland-processing-animation).
+- Kathryn Killebrew [@Banderkat](https://twitter.com/Banderkat)
+  -  Lessons from working on trip routing for [GoPhillyGo](https://gophillygo.org), a trip planning tool for biking, walking, and transit.
+  - [Slides](presentations/2018-05-23_Killebrew_GoPhillyGo.pdf)
+- Jiaxu Zhou
+  - Analytical methods for mapping potential Citibike usage in the outer boroughs.
+- Dan Vanderkam [@danvdk](https://twitter.com/danvdk)
+  - Insights from [NYC Transit Explorer](https://transit.sidewalklabs.com/), a tool built by Sidewalk Labs which shows how long it would take to get anywhere in the city via transit, including scenario analysis.

--- a/_events/transit-techies-nyc-1.md
+++ b/_events/transit-techies-nyc-1.md
@@ -9,7 +9,7 @@ address: "10 Hudson Yards, New York, NY 10001"
 ## Meetup information
 
 - RSVP: [Click to go to meetup.com to RSVP](https://www.meetup.com/Transit-Techies-NYC/events/249952831/)
-- Date: {% if page.date %}{{ page.date | date: "%A, %B %-d, %Y" }}{% endif %}
+- Date: {% if page.eventdate %}{{ page.eventdate | date: "%A, %B %-d, %Y" }}{% endif %}
 - Time: 7:00 PM to 9:00 PM
 - Where: {% if page.location %}{{ page.location }}{% endif %}, {% if page.address %}{{ page.address }}{% endif %}
 

--- a/_events/transit-techies-nyc-2.md
+++ b/_events/transit-techies-nyc-2.md
@@ -9,7 +9,7 @@ address: "10 Hudson Yards, New York, NY 10001"
 ## Meetup information
 
 - RSVP: [Click to go to meetup.com to RSVP](https://www.meetup.com/Transit-Techies-NYC/events/252950626/)
-- Date: {% if page.date %}{{ page.date | date: "%A, %B %-d, %Y" }}{% endif %}
+- Date: {% if page.eventdate %}{{ page.eventdate | date: "%A, %B %-d, %Y" }}{% endif %}
 - Time: 6:30 PM to 8:30 PM
 - Where: {% if page.location %}{{ page.location }}{% endif %}, {% if page.address %}{{ page.address }}{% endif %}
 

--- a/_events/transit-techies-nyc-2.md
+++ b/_events/transit-techies-nyc-2.md
@@ -1,0 +1,39 @@
+---
+layout: event
+title: "Transit Techies NYC 2: Second Avenue Segfaults"
+date: "2018-07-11T18:30-04:00"
+location: "Intersection"
+address: "10 Hudson Yards, New York, NY 10001"
+---
+
+## Meetup information
+
+- RSVP: [Click to go to meetup.com to RSVP](https://www.meetup.com/Transit-Techies-NYC/events/252950626/)
+- Date: {% if page.date %}{{ page.date | date: "%A, %B %-d, %Y" }}{% endif %}
+- Time: 6:30 PM to 8:30 PM
+- Where: {% if page.location %}{{ page.location }}{% endif %}, {% if page.address %}{{ page.address }}{% endif %}
+
+Will Fisher of MTA will discuss his work with Long Island Rail Road digital projects.
+
+Assel Dmitriyeva of NYU Tandon will demo a microtransit tool, which acts as a destination recommender system for mobility-on-demand services.
+
+Mary Buchanan from TransitCenter will explore how they built the busturnaround.nyc API and the analysis that underlies the bus report cards.
+
+Alex Hill, David Bromwich, and Josselin Philippe of Motivate will talk about building Bike Inspector, their app for tracking Citi Bike repair activity. They will cover how Bike Inspector works today to validate bike assets improve the flow of work orders.
+
+## Written recap
+
+Recap by [Pranav Badami](https://twitter.com/Pranav_Badami) on [HackerNoon](https://hackernoon.com/four-projects-improving-transportation-in-new-york-city-905fb4cd8bac).
+
+## Speakers and links
+
+- Will Fisher [@wafisher](https://twitter.com/wafisher), MTA Long Island Rail Road
+  - How to convert LIRR track schematics into a graph to inform passengers of real-time train data.
+- Assel Dmitriyeva, NYU Tandon
+  - Methods for building a microtransit tool, which acts as a destination recommender system for mobility-on-demand services.
+  - Coverage from [C2SMART](http://c2smart.engineering.nyu.edu/2018/07/13/c2smart-student-presents-at-transit-techies-nyc/) at NYU Tandon.
+- Mary Buchanan [@Mary_LBee](https://twitter.com/Mary_LBee), TransitCenter
+  - Results from the GTFS-realtime data cleaning (by Neil Freeman [@fitnr](https://twitter.com/fitnr)) to produce the bus report cards for [Bus Turnaround](http://busturnaround.nyc).
+  - [Slides](presentations/2018-07-11_Buchanan_BusTurnaround.pdf)
+- Alex Hill, David Bromwich, and Josselin Philippe, Motivate
+  - What inspired the building of Bike Inspector, the Motivate app for tracking Citi Bike repair activity, and how it works to validate bike assets to improve the flow of work orders.

--- a/_events/transit-techies-nyc-3.md
+++ b/_events/transit-techies-nyc-3.md
@@ -1,0 +1,37 @@
+---
+layout: event
+title: "Transit Techies NYC 3: sudo touch third_rail"
+eventdate: "2018-08-29T18:30-04:00"
+location: "Intersection"
+address: "10 Hudson Yards, New York, NY 10001"
+---
+
+## Meetup information
+
+- RSVP: [Click to go to meetup.com to RSVP](https://www.meetup.com/Transit-Techies-NYC/events/252950626/)
+- Date: {% if page.eventdate %}{{ page.eventdate | date: "%A, %B %-d, %Y" }}{% endif %}
+- Time: 6:30 PM to 8:30 PM
+- Where: {% if page.location %}{{ page.location }}{% endif %}, {% if page.address %}{{ page.address }}{% endif %}
+
+Kate Chanba and David Emory of Conveyal will explore TransitiveJS, a library to produce transit map schematics. Kate will discuss using it for cartographic design, and David will explore its use with TriMet.
+
+Ray Cha will show his Open Transit Data Toolkit, a project funded by TransitCenter which helps analyze and visualize transit data.
+
+Noah Greenbaum of Coord will show their recently-launched Bikeshare API and demonstrate use-cases complete with API calls.
+
+## Written recap
+
+Recap by [Michael Zhang](https://twitter.com/mzhang13) on [Medium](https://medium.com/@mzhang13/three-projects-helping-to-build-better-transit-tools-for-the-future-bb3176c0f47b).
+
+## Speakers and links
+
+- Kate Chanba [@kchanba](https://twitter.com/kchanba) and David Emory [@martarider](https://twitter.com/martarider)
+  - Design and technical challenges with producing programmatically generated transit schematic maps in [transitive.js](https://github.com/conveyal/transitive.js/).
+  - [Slides](presentations/2018-08-29_ChanbaEmory_transitivejs.pdf)
+- Ray Cha [@weatherpattern](https://twitter.com/weatherpattern)
+  - Getting started developing with open data using the [Open Transit Data Toolkit](https://transitdatatoolkit.com/).
+  - Coverage from [project blog](https://transitdatatoolkit.com/2018/10/08/recent-presentations/).
+  - [Slides](https://weatherpattern.github.io/transit-techies-180829/#/)
+- Noah Greenbaum
+  - How Coord consolidated bike share APIs across the country to create their unified [Bike Share API](https://coord.co/docs/bike) and it can be queried.
+  - [Slides](presentations/2018-08-29_Greenbaum_Coord.pdf)

--- a/_events/transit-techies-nyc-4.md
+++ b/_events/transit-techies-nyc-4.md
@@ -1,0 +1,47 @@
+---
+layout: event
+title: "Transit Techies NYC 4: Four the Love of Transit"
+eventdate: "2018-10-17T18:30-04:00"
+location: "Intersection"
+address: "10 Hudson Yards, New York, NY 10001"
+---
+
+## Meetup information
+
+- RSVP: [Click to go to meetup.com to RSVP](https://www.meetup.com/Transit-Techies-NYC/events/254580357/)
+- Date: {% if page.eventdate %}{{ page.eventdate | date: "%A, %B %-d, %Y" }}{% endif %}
+- Time: 6:30 PM to 8:30 PM
+- Where: {% if page.location %}{{ page.location }}{% endif %}, {% if page.address %}{{ page.address }}{% endif %}
+
+Pranav Badami and Michael Zhang have spent the past 6+ months scraping and storing data on over 100,000+ NJ Transit trains. They’ll talk about how they scraped the data, how you can access it, and some interesting data analysis of the country’s 3rd busiest commuter railway.
+
+Candy Chan will tell us about Project Subway, her work documenting and visualizing the 3D space of NYC subway stations. (http://www.projectsubwaynyc.com/)
+
+Alex Bell will talk about his personal project using computer vision to study the amount of time bus stops and bike lanes are blocked on the streets of NYC.
+
+Kurt Raschke from MTA New York City Transit will discuss how they implemented TunnelView, which gives NYCT spherical imagery of tracks and station interiors.
+
+## Written recap
+
+Recap by [Matt Joseph](https://twitter.com/mattjoseph0) on [Medium](https://medium.com/@mattjoseph/recap-transit-techies-nyc-4-four-the-love-of-transit-317b6fcb8a31).
+
+## Speakers and links
+
+- Pranav Badami [@Pranav_Badami](https://twitter.com/Pranav_Badami) and Michael Zhang [@mzhang13](https://twitter.com/mzhang13)
+  - How they scraped 6+ months of NJ Transit data for over 100,000+ trains, how you can access it, and some interesting data analysis of the country’s 3rd busiest commuter railway.
+  - [Kaggle Data Set](https://www.kaggle.com/pranavbadami/nj-transit-amtrak-nec-performance)
+  - [Blog Post](https://towardsdatascience.com/the-5-stages-of-a-system-breakdown-on-nj-transit-8258127e31e9)
+  - [Slides](presentations/2018-10-17_BadamiZhang_NJTransit.pdf)
+  - [Video](https://www.youtube.com/watch?v=-IdTpH_ZvXw)
+- Candy Chan [@projsubwaynyc](https://twitter.com/projsubwaynyc)
+  - How she built [Project Subway NYC](http://www.projectsubwaynyc.com/), her work documenting and visualizing the 3D space of NYC subway stations.
+  - [Video](https://www.youtube.com/watch?v=Roc-U1eG5ow)
+- Alex Bell [@Bellspringsteen](https://twitter.com/Bellspringsteen)
+  - Using computer vision to study the amount of time bus stops and bike lanes are blocked on the streets of NYC, specifically by UPS trucks.
+  - [NYTimes Article](https://www.nytimes.com/2018/03/15/nyregion/bike-lane-blocked-new-york.html)
+  - [GitHub Repo](https://github.com/Bellspringsteen/OurCamera)
+  - [Slides](presentations/2018-10-17_Bell_StatusQuoEverythingSucks.pdf)
+  - [Video](https://www.youtube.com/watch?v=ZGPltKDUhUU)
+- Kurt Raschke [@kurtraschke](https://twitter.com/kurtraschke), MTA New York City Transit
+  - How MTA implemented TunnelView, which gives NYCT spherical imagery of tracks and station interiors.
+  - [Video](https://www.youtube.com/watch?v=JWaIHlogYIc)

--- a/_events/transit-techies-nyc-5.md
+++ b/_events/transit-techies-nyc-5.md
@@ -1,0 +1,37 @@
+---
+layout: event
+title: "Transit Techies NYC 5: GTF5"
+eventdate: "2018-11-28T18:30-05:00"
+location: "Intersection"
+address: "10 Hudson Yards, New York, NY 10001"
+---
+
+## Meetup information
+
+- RSVP: [Click to go to meetup.com to RSVP](https://www.meetup.com/Transit-Techies-NYC/events/255842450/)
+- Date: {% if page.eventdate %}{{ page.eventdate | date: "%A, %B %-d, %Y" }}{% endif %}
+- Time: 6:30 PM to 8:30 PM
+- Where: {% if page.location %}{{ page.location }}{% endif %}, {% if page.address %}{{ page.address }}{% endif %}
+
+Abhijit Valluri will share how he pulled in MTA real-time arrivals into a personal transit app for his Garmin smartwatch.
+
+Mallory Bulkley will demo her data visualization of Citibike trips taken in a single day, filtered by various rider demographics.
+
+Scott Morris will present on the features of the MyMTA mobile app, which was recently launched as the official app of the MTA with real-time information across modes and agencies.
+
+## Written recap
+
+Recap by [Matt Joseph](https://twitter.com/mattjoseph0) on [Medium](https://medium.com/@mattjoseph/recap-transit-techies-5-gtf5-950673bdce51).
+
+## Speakers and links
+
+- Abhijit Valluri
+  - Fetching MTA real-time arrivals for a personal transit app for his Garmin smartwatch, including an exploration of GTFS-RT, protocol buffers, and agency-specific extensions.
+  - [Video](https://www.youtube.com/watch?v=7ugSNfB-xJ0)
+- Mallory Bulkley [@mallorybulkley](https://twitter.com/mallorybulkley/)
+  - [A Day in the Life of Citi Bike](https://mallorybulkley.com/citi-bike-visualization/): Visualization of all Citibike trips taken in a single day, filtered by various rider demographics.
+  - [GitHub Repo](https://github.com/mallorybulkley/citi-bike-visualization)
+  - [Video](https://www.youtube.com/watch?v=pp2cy0DaEsA)
+- Scott Morris [@smorris777](https://twitter.com/smorris777)
+  - Latesting and upcoming features of the MYmta mobile app, which was recently launched as the official app of the MTA with real-time information across modes and agencies.
+  - [Video](https://www.youtube.com/watch?v=W8dS1de7xEM)

--- a/_events/transit-techies-nyc-6.md
+++ b/_events/transit-techies-nyc-6.md
@@ -1,0 +1,44 @@
+---
+layout: event
+title: "Transit Techies NYC 6: Six-Car Train"
+eventdate: "2019-01-30T18:30-05:00"
+location: "Intersection"
+address: "10 Hudson Yards, New York, NY 10001"
+---
+
+## Meetup information
+
+- RSVP: [Click to go to meetup.com to RSVP](https://www.meetup.com/Transit-Techies-NYC/events/256886666/)
+- Date: {% if page.eventdate %}{{ page.eventdate | date: "%A, %B %-d, %Y" }}{% endif %}
+- Time: 6:30 PM to 8:30 PM
+- Where: {% if page.location %}{{ page.location }}{% endif %}, {% if page.address %}{{ page.address }}{% endif %}
+
+Francis Tseng will kick us off talking about his work modeling and simulating transit demand within the Brazilian city of Belo Horizonte as part of his research collaboration with the Institute for Applied Economic Research in Brazil.
+
+Sunny Zheng will talk about his North American Intercity Rail Tools map (more commonly known as ASM), which is a culmination of his efforts to increase access to Amtrak real time data.
+
+Jacqueline Klopp will present the Digital Matatus project, a joint effort to use smartphone data to map the informal minivan (matatu) transportation system in Nairobi.
+
+Lauren Tarte and Anne Halvorsen will round up the evening with a discussion of the recent Subway and Bus Performance Dashboards that the Data/Research/Development group at New York City Transit have worked on, improving transparency and leveraging passenger-centric performance metrics.
+
+
+## Written recap
+
+Recap by [Matt Joseph](https://twitter.com/mattjoseph0) on [Medium](https://medium.com/@mattjoseph/recap-transit-techies-nyc-6-six-car-train-1a91b22e3815).
+
+## Speakers and links
+
+- Francis Tseng [@frnsys](https://twitter.com/frnsys/)
+  - [Modeling and simulating transit demand](https://spaceandtim.es/code/public_transit_routing/) within the Brazilian city of Belo Horizonte using OpenStreetMap, GTFS, and Connection Scan Algorithm.
+  - [GitHub Repo](https://github.com/frnsys/transit_demand_model)
+  - [Video](https://www.youtube.com/watch?v=Dn4uyaeMVRA)
+- Sunny Zheng [@SunnysWords](https://twitter.com/SunnysWords/)
+  - How he built and maintained the [North America Intercity Rail Tools map](https://asm.transitdocs.com/) (more commonly known as ASM), which is a culmination of his efforts to increase access to Amtrak real time data.
+  - [Video](https://www.youtube.com/watch?v=uYiWw-Hr1aU)
+- Jacqueline Klopp [@jmklopp1](https://twitter.com/jmklopp1/)
+  - The [Digital Matatus](http://www.digitalmatatus.com/) project, a joint effort to use smartphone data to map the informal minivan (matatu) transportation system in Nairobi.
+  - [Video](https://www.youtube.com/watch?v=8XilfmI4Nh4)
+- Lauren Tarte [@RacingTheNTrain](https://twitter.com/RacingTheNTrain/) and Anne Halvorsen
+  - Measuring MTA New York City Transit performance in a passenger-centric way and [building a dashboard](http://dashboard.mta.info/) for public accountability on new metrics such as Customer Journey Time Performance.
+  - [Slides](presentations/2019-01-30_TarteHalvorsen_MTADashboardsMetrics.pdf)
+  - [Video](https://www.youtube.com/watch?v=DH0cA_ZLbDI)

--- a/_events/transit-techies-nyc-7.md
+++ b/_events/transit-techies-nyc-7.md
@@ -1,0 +1,45 @@
+---
+layout: event
+title: "Transit Techies NYC 7: Seven Minute Delay"
+eventdate: "2019-03-20T18:30-05:00"
+location: "Intersection"
+address: "10 Hudson Yards, New York, NY 10001"
+---
+
+## Meetup information
+
+- RSVP: [Click to go to meetup.com to RSVP](https://www.meetup.com/Transit-Techies-NYC/events/259203820/)
+- Date: {% if page.eventdate %}{{ page.eventdate | date: "%A, %B %-d, %Y" }}{% endif %}
+- Time: 6:30 PM to 8:30 PM
+- Where: {% if page.location %}{{ page.location }}{% endif %}, {% if page.address %}{{ page.address }}{% endif %}
+
+Sunny Ng will open the night talking about how he built goodservice.io and how it can detect delays and issue alerts faster than MTA-issued alerts.
+
+Samara Trilling, Sidewalk Labs' accessibility lead, will walk us through their recently-released digital and physical Accessibility Principles. These principles were development in collaboration with the Toronto accesibility community and include things from wayfinding experiences in public parks, to accessible ways of hailing AVs, to the infrastructure needed to support new assistive technologies.
+
+Will Geary will explore Wayfinder3D, an application he built which fetches route recommendations from the Google Maps API and plots them on a 3D globe. This will be Will's second time presenting at Transit Techies NYC.
+
+Eric Goldwyn will wrap up the night by presenting his work on a redesign of the Brooklyn bus network he built with fellow transit-expert Alon Levy. Their redesign focused on improving average bus speeds and included extensive analysis of BusTime, ridership, and land-use data.
+
+
+## Written recap
+
+Recap by [Pranav Badami](https://twitter.com/Pranav_Badami) on [Medium](https://medium.com/@pranavbadami/recap-transit-techies-nyc-7-7-minute-delay-37d334026fa3).
+
+## Speakers and links
+
+- Sunny Ng [@\_blahblahblah](https://twitter.com/_blahblahblah)
+  - Building [goodservice.io](https://www.goodservice.io/trains) to keep New Yorkers better informed about real-time subway service statu
+  - [GitHub Repo](https://github.com/blahblahblah-/goodservice)
+  - [Slides](https://speakerdeck.com/blahblahblah/goodservice-dot-io)
+  - [Video](https://youtu.be/tidjA5EJnl0)
+- Samara Trilling - [(LinkedIn)](https://www.linkedin.com/in/samaratrilling/)
+  - Collaboratively ideating and designing with local groups to create a set of transit-related [accessibility principles](https://medium.com/sidewalk-toronto/co-designing-a-more-accessible-community-d6377599f4ce) for smart cities, as the accessibility lead at Sidewalk Labs
+- Will Geary [@wgeary](https://twitter.com/wgeary)
+  - Building the Wayfinder3D animation tool and CLI to interactively compare multi-modal transportation options in cities
+  - [GitHub Repo](https://github.com/willgeary/Wayfinder3D)
+  - [Video](https://youtu.be/9WiTyKr1B0k)
+- Eric Goldwyn [@ericgoldwyn](https://twitter.com/ericgoldwyn)
+  - [Redesigning the Brooklyn bus network](https://www.citylab.com/perspective/2018/11/brooklyn-bus-route-redesign-mta-new-york/575716/) by creating a model to evaluate the impact of various bus network best practices
+  - In conjuction with [Alon Levy](https://twitter.com/alon_levy)
+  - [Video](https://youtu.be/V3x12ApF28Q)

--- a/_events/transit-techies-nyc-8.md
+++ b/_events/transit-techies-nyc-8.md
@@ -1,0 +1,30 @@
+---
+layout: event
+title: "Transit Techies NYC 8"
+eventdate: "2019-05-08T18:30-05:00"
+location: "Intersection"
+address: "10 Hudson Yards, New York, NY 10001"
+---
+
+## Meetup information
+
+- RSVP: [Click to go to meetup.com to RSVP](https://www.meetup.com/Transit-Techies-NYC/events/260083847/)
+- Date: {% if page.eventdate %}{{ page.eventdate | date: "%A, %B %-d, %Y" }}{% endif %}
+- Time: 6:30 PM to 8:30 PM
+- Where: {% if page.location %}{{ page.location }}{% endif %}, {% if page.address %}{{ page.address }}{% endif %}
+
+Mary Buchanan from TransitCenter will be returning to talk about Transit Insights, a new interactive data tool from TransitCenter. This allows users to measure, compare, and share recent transit ridership trends, for US agencies and regions.
+
+Lucas Marxen of the Rutgers New Jersey Agricultural Experiment Station will show the New Jersey Land Use + Transit Data Application and how it is being used by New Jersey Transit.
+
+Clara Chung from Teralytics will demo their product Matrix, which uses telecommunications data to estimate trip volume nationwide, and some of the insights gleaned from it.
+
+Adam Pearce will round up the evening with talking about transit visualization work that he did as a graphics editor at The New York Times, as well as relevant personal projects.
+
+## Written recap
+
+Coming soon!
+
+## Speakers and links
+
+Coming soon!

--- a/_includes/head-event-jsonld.html
+++ b/_includes/head-event-jsonld.html
@@ -1,0 +1,20 @@
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Event",
+  "name": "{% if page.title %}{{ page.title }}{% endif %}",
+  "startDate": "{% if page.eventdate %}{{ page.eventdate | date_to_xmlschema }}{% endif %}",
+  "location": {
+    "@type": "Place",
+    "name": "Intersection",
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "10 Hudson Yards",
+      "addressLocality": "New York",
+      "postalCode": "10001",
+      "addressRegion": "NY",
+      "addressCountry": "US"
+    }
+  }
+}
+</script>

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -1,0 +1,31 @@
+<!--- Copyright 2019 Transit Techies -->
+<!doctype html>
+<html amp="" lang="en">
+<head>
+  {% include head-meta.html %}
+  {% include head-scripts.html %}
+  {% include head-styles.html %}
+  {% include head-event-jsonld.html %}
+</head>
+<body>
+  {% include body-serviceworker.html %}
+  {% include body-analytics.html %}
+  {% include body-navbar.html %}
+
+  <article class="section-purple">
+    <h1 class="center">{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</h1>
+    <h2 class="center">{% if page.eventdate %}{{ page.eventdate | date: "%A, %B %-d, %Y" }}{% endif %}</h2>
+  </article>
+
+  <article id="schedule">
+    <div class="pure-g">
+      <div class="pure-u-md-1-4"></div>
+      <div class="pure-u-1 pure-u-md-1-2">
+        {{ content }}
+      </div>
+    </div>
+  </article>
+
+  {% include body-footer.html %}
+</body>
+</html>

--- a/past.html
+++ b/past.html
@@ -13,7 +13,15 @@ permalink: /past
   <div class="pure-g">
     <div class="pure-u-md-1-4"></div>
     <div class="pure-u-1 pure-u-md-1-2">
-      {% include talks.md %}
+      <ul>
+        <h2 class="center text-purple">Previous Talks</h2>
+        <p class="center">A library of slides and demos from past presenters.</p>
+        {% for event in site.events %}
+          <li>
+            <a href="{{ event.url }}">{{ event.title }}</a>
+          </li>
+        {% endfor %}
+      </ul>
     </div>
   </div>
 </article>


### PR DESCRIPTION
This PR splits up the large "Past Events" page into a page per each event/meetup. This means that we can link to each event individually for details. The events use some config at the top in order to define the date, address information, etc.

These pages also use a slightly different layout, which includes a JSON-LD tag that (should) mark it as an event.