### PR TITLE
Resize hero image to be smaller

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,8 +47,8 @@ permalink: /
 
 <article class="section-white" id="about">
   <div class="pure-g">
-    <div class="pure-u-md-1-8"></div>
-    <div class="pure-u-1 pure-u-md-3-4">
+    <div class="pure-u-md-1-4"></div>
+    <div class="pure-u-1 pure-u-md-1-2">
       <amp-img src="../img/header4.jpg" width="2000" height="1111" layout="responsive" alt="Meetup photo" class="header-image"></amp-img>
     </div>
   </div>


### PR DESCRIPTION
This PR resizes the main hero image to be a bit smaller. On a full-size screen, it was causing the user to scroll quite a bit to reach the text.