### PR TITLE
Update written recap links

### DIFF
--- a/_events/transit-techies-nyc-4.md
+++ b/_events/transit-techies-nyc-4.md
@@ -24,7 +24,7 @@ Kurt Raschke from MTA New York City Transit will discuss how they implemented Tu
 
 ## Written Recap
 
-Recap by [Matt Joseph](https://twitter.com/mattjoseph0) on [Medium](https://medium.com/@mattjoseph/recap-transit-techies-nyc-4-four-the-love-of-transit-317b6fcb8a31).
+[Click here for a written recap](https://mattj.io/posts/2018-10-18-recap-transit-techies-4-four-the-love-of-transit/) by [Matt Joseph](https://twitter.com/mattjoseph0).
 
 ## Speakers and Links
 

--- a/_events/transit-techies-nyc-5.md
+++ b/_events/transit-techies-nyc-5.md
@@ -22,7 +22,7 @@ Scott Morris will present on the features of the MyMTA mobile app, which was rec
 
 ## Written Recap
 
-Recap by [Matt Joseph](https://twitter.com/mattjoseph0) on [Medium](https://medium.com/@mattjoseph/recap-transit-techies-5-gtf5-950673bdce51).
+[Click here for a written recap](https://mattj.io/posts/2018-12-04-recap-transit-techies-5-gtf5/) by [Matt Joseph](https://twitter.com/mattjoseph0).
 
 ## Speakers and Links
 

--- a/_events/transit-techies-nyc-6.md
+++ b/_events/transit-techies-nyc-6.md
@@ -25,7 +25,7 @@ Lauren Tarte and Anne Halvorsen will round up the evening with a discussion of t
 
 ## Written Recap
 
-Recap by [Matt Joseph](https://twitter.com/mattjoseph0) on [Medium](https://medium.com/@mattjoseph/recap-transit-techies-nyc-6-six-car-train-1a91b22e3815).
+[Click here for a written recap](https://mattj.io/posts/2019-02-08-recap-transit-techies-6-six-car-train/) by [Matt Joseph](https://twitter.com/mattjoseph0).
 
 ## Speakers and Links
 


### PR DESCRIPTION
This PR updates the links for the recaps that I wrote. I have been relocating my posts due to the increasing prevalence of [the Medium paywall](https://help.medium.com/hc/en-us/articles/360017581433-About-the-metered-paywall). This increases the number of people who can freely access the content.