### PR TITLE
Re-add CNAME so the site functions as an archive

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+transittechies.nyc


### PR DESCRIPTION
Although the domain and CNAME were removed in d721446519cea152e0bf2ba7966927cc5159fee1, the site is still available via https://transittechies.github.io and is one of the top results on Google. Since the meetup is now being run by another organizer, #22 updates the site to be an archive and to point to the meetup group.

This PR ad-adds the CNAME since a domain is preferred over the GitHub subdomain. Refer to #22 and later PRs for updates to actual content.