### PR TITLE
Replace Meetup link with Luma

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,9 +9,9 @@ permalink: /
     <div class="pure-u-1 pure-u-md-3-5">
       <div class="next-event-hero">
         <h1 class="center">Transit Techies NYC</h1>
-        <span class="next-event-callout center">This site is in archive mode. Visit the Transit Techies NYC meetup group for the latest information:</span>
+        <span class="next-event-callout center">This site is in archive mode. Visit the Transit Techies NYC calendar for the latest information:</span>
         <div class="centering-div">
-          <a href="https://www.meetup.com/transit-techies-nyc/" target="_blank" rel="noopener" class="pure-button button-white button-white-primary button-xlarge">Go to meetup group</a>
+          <a href="https://luma.com/transittechies" target="_blank" rel="noopener" class="pure-button button-white button-white-primary button-xlarge">Go to Luma calendar</a>
           <a href="https://www.transittechies.com" target="_blank" rel="noopener" class="pure-button button-white button-white-primary button-xlarge">Go to current site</a>
         </div>
       </div>


### PR DESCRIPTION
We moved out of Meetup due to increasing enshittification, we're on Luma now.